### PR TITLE
Adding ability to set (and revert to) a default configuration.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,6 +34,21 @@ To change a configuration variable at runtime:
   
 You should populate your class with the default values for every configuration variable that might be accessed. If you try and access a variable that does not exist, Mixlib::Config will throw an <ArgumentError>.
 
+You can also configure defaults:
+
+  class MyConfig
+    extend(Mixlib::Config)
+    configure_defaults do |c|
+      c[:first_value] = 'something'
+    end
+  end
+
+  MyConfig.first_value   # returns 'something'
+  MyConfig.first_value('foobar')    # sets first_value to 'foobar'
+  MyConfig.first_value   # returns 'foobar'
+  MyConfig.defaults!
+  MyConfig.first_value   # returns 'something'
+
 To load a ruby configuration file (which will evaluate in the context of your configuration class):
 
   MyConfig.from_file('your_config_file.rb')

--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -22,7 +22,7 @@ module Mixlib
   module Config
 
     def self.extended(base)
-      class << base; attr_accessor :configuration; end
+      class << base; attr_accessor :configuration; attr_accessor :default_configuration; end
       base.configuration = Hash.new
     end 
     
@@ -44,7 +44,26 @@ module Mixlib
     def configure(&block)
       block.call(self.configuration)
     end
-    
+
+    # Pass Mixlib::Config.configure_defualts() a block, and it reset the configuration,
+    # yield self.configuration, and save the defaults.
+    #
+    # === Parameters
+    # <block>:: A block that is sent self.configuration as its argument
+    def configure_defaults(&block)
+      self.configuration = {}
+      block.call(self.configuration)
+      self.default_configuration = self.hash_dup
+    end
+
+    # Reverts to the default configuration set in the 'configure_defaults' block.
+    #
+    # === Parameters
+    # <block>:: A block that is sent self.configuration as its argument
+    def defaults!
+      self.configuration = self.default_configuration if self.default_configuration
+    end
+
     # Get the value of a configuration option
     #
     # === Parameters

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -73,7 +73,37 @@ describe Mixlib::Config do
     ConfigIt.arbitrary_value.should == 50
     ConfigIt[:arbitrary_value].should == 50
   end
-  
+
+  describe "when a block has been used to set default config values" do
+    before do
+      ConfigIt.configure_defaults { |c| c[:contestant_a] = "dire_wolf"; c[:contestant_b] = "giant_short_faced_bear" }
+    end
+
+    it "clears old configuration" do
+      ConfigIt.alpha.should == nil
+    end
+
+    {:contestant_a => "dire_wolf", :contestant_b => "giant_short_faced_bear"}.each do |k,v|
+      it "should allow you to retrieve the config value for #{k} via []" do
+        ConfigIt[k].should == v
+      end
+      it "should allow you to retrieve the config value for #{k} via method_missing" do
+        ConfigIt.send(k).should == v
+      end
+    end
+
+    it "should allow defaults to be overwritten" do
+      ConfigIt[:contestant_a] = "cave_panda"
+      ConfigIt[:contestant_a].should == "cave_panda"
+    end
+
+    it "should reset the overwritten values to defaults" do
+      ConfigIt[:contestant_a] = "cave_panda"
+      ConfigIt.defaults!
+      ConfigIt[:contestant_a].should == "dire_wolf"
+    end
+  end
+
   describe "when a block has been used to set config values" do
     before do
       ConfigIt.configure { |c| c[:cookbook_path] = "monkey_rabbit"; c[:otherthing] = "boo" }


### PR DESCRIPTION
Hey,

I just started using mixlib-config for a new project, and found myself wishing I could reset to a default configuration, especially when testing.  I think others might find this useful as well.  This could be achieved in the Mixlib::Config subclass as well, rather than in Mixlib::Config itself, but it might be a convenient addition. Thanks, -nick
