### PR TITLE
add require 'rspec' to spec/spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $TESTING=true
 $:.push File.join(File.dirname(__FILE__), '..', 'lib')
 
+require 'rspec'
 require 'mixlib/config'
 
 class ConfigIt


### PR DESCRIPTION
to fix "undefined method `describe' for main:Object (NoMethodError)"
