### PR TITLE
Rename has_key? -> key? (BC compatible)

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -92,9 +92,10 @@ module Mixlib
     # === Returns
     # <True>:: If the config option exists
     # <False>:: If the config option does not exist
-    def has_key?(key)
+    def key?(key)
       self.configuration.has_key?(key.to_sym)
     end
+    alias_method :has_key?, :key?
 
     # Resets a config option to its default.
     #


### PR DESCRIPTION
Ruby has moved away from has_key?, so mixlib should as well.
