### PR TITLE
Allow configuring contexts via block

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,30 @@ Often you want to be able to group configuration options to provide a common con
   end
 ```
 
-The user can write their config file like this:
+The user can write their config file in one of three formats:
 
+#### Method Style
 ```ruby
-  logging.base_filename 'superlog'
-  logging.max_log_files 2
+logging.base_filename 'superlog'
+logging.max_log_files 2
+```
+
+#### Block Style
+Using this format the block is executed in the context, so all configurables on that context is directly accessible
+```ruby
+logging do
+  base_filename 'superlog'
+  max_log_files 2
+end
+```
+
+#### Block with Argument Style
+Using this format the context is given to the block as an argument
+```ruby
+logging do |l|
+  l.base_filename = 'superlog'
+  l.max_log_files = 2
+end
 ```
 
 You can access these variables thus:

--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -460,7 +460,12 @@ module Mixlib
       meta.send :define_method, symbol do |*args, &block|
         # If a block was given, eval it in the context
         if block
-          context_eval(symbol, &block)
+          # If the block expects no arguments, then instance_eval
+          if block.arity == 0
+            context_eval(symbol, &block)
+          else # yield to the block
+            context_yield(symbol, &block)
+          end
         else
           internal_get_or_set(symbol, *args)
         end
@@ -469,6 +474,10 @@ module Mixlib
 
     def context_eval(context, &block)
       internal_get(context).instance_eval(&block)
+    end
+
+    def context_yield(context)
+      yield internal_get(context)
     end
   end
 end

--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -457,9 +457,18 @@ module Mixlib
         internal_set(symbol, value)
       end
       # Getter
-      meta.send :define_method, symbol do |*args|
-        internal_get_or_set(symbol, *args)
+      meta.send :define_method, symbol do |*args, &block|
+        # If a block was given, eval it in the context
+        if block
+          context_eval(symbol, &block)
+        else
+          internal_get_or_set(symbol, *args)
+        end
       end
+    end
+
+    def context_eval(context, &block)
+      internal_get(context).instance_eval(&block)
     end
   end
 end

--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -462,22 +462,14 @@ module Mixlib
         if block
           # If the block expects no arguments, then instance_eval
           if block.arity == 0
-            context_eval(symbol, &block)
+            internal_get(symbol).instance_eval(&block)
           else # yield to the block
-            context_yield(symbol, &block)
+            block.yield(internal_get(symbol))
           end
         else
           internal_get_or_set(symbol, *args)
         end
       end
-    end
-
-    def context_eval(context, &block)
-      internal_get(context).instance_eval(&block)
-    end
-
-    def context_yield(context)
-      yield internal_get(context)
     end
   end
 end

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -763,6 +763,15 @@ describe Mixlib::Config do
       @klass.blah.y.should == 20
     end
 
+    it "setting the context values in a yielded block overrides the default values" do
+      @klass.blah do |b|
+        b.x = 10
+        b.y = 20
+      end
+      @klass.blah.x.should == 10
+      @klass.blah.y.should == 20
+    end
+
     it "after reset of the parent class, children are reset" do
       @klass.blah.x = 10
       @klass.blah.x.should == 10

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -754,6 +754,15 @@ describe Mixlib::Config do
       @klass.blah.z.should == 10
     end
 
+    it "setting the context values in a block overrides the default values" do
+      @klass.blah do
+        x 10
+        y 20
+      end
+      @klass.blah.x.should == 10
+      @klass.blah.y.should == 20
+    end
+
     it "after reset of the parent class, children are reset" do
       @klass.blah.x = 10
       @klass.blah.x.should == 10


### PR DESCRIPTION
This will allow configuring values in `context`'s using blocks.

Given this `Mixlib::Config` class:
```ruby
require 'mixlib/config'
module MyConfig
  extend Mixlib::Config
  default :a, 30
  config_context :example do
      default :x, 10
      config_context :nested do
        default :z, 30
      end
  end
end
```

The current implementation requires a config file like so:
```ruby
a 45
example.x 40
example.nested.z 42
```

With the changes in this pull request you would also be able to have a config file like so:
```ruby
a 45
example do
  x 32
  nested do
    z 12
  end
end
```
