### PR TITLE
Restore by swapping in saved state instead of 'reset and merge'

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -177,16 +177,20 @@ module Mixlib
 
     # Restore non-default values from the given hash.
     #
-    # This method is the equivalent of +reset+ followed by +merge!(hash)+.
-    #
     # === Parameters
     # hash<Hash>: a hash in the same format as output by save.
-    #
+    # 
     # === Returns
     # self
     def restore(hash)
-      reset
-      merge!(hash)
+      self.configuration = hash.reject { |key, value| config_contexts.has_key?(key) }
+      config_contexts.each do |key, config_context|
+        if hash.has_key?(key)
+          config_context.restore(hash[key])
+        else
+          config_context.reset
+        end
+      end
     end
 
     # Merge an incoming hash with our config options

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -788,6 +788,7 @@ describe Mixlib::Config do
         config_context(:blah) do
           config_context(:yarr) do
             default :x, 5
+            default :y, 6
           end
         end
         configurable :x
@@ -796,11 +797,14 @@ describe Mixlib::Config do
 
     it "configurable defaults in that context work" do
       expect(@klass.blah.yarr.x).to eql(5)
+      expect(@klass.blah.yarr.y).to eql(6)
     end
 
     it "after setting values in the context, the values remain set" do
       @klass.blah.yarr.x = 10
+      @klass.blah.yarr.y = 11
       expect(@klass.blah.yarr.x).to eql(10)
+      expect(@klass.blah.yarr.y).to eql(11)
     end
 
     it "setting values with the same name in the parent context do not affect the child context" do
@@ -811,9 +815,12 @@ describe Mixlib::Config do
 
     it "after reset of the parent class, children are reset" do
       @klass.blah.yarr.x = 10
+      @klass.blah.yarr.y = 11
       expect(@klass.blah.yarr.x).to eql(10)
+      expect(@klass.blah.yarr.y).to eql(11)
       @klass.reset
       expect(@klass.blah.yarr.x).to eql(5)
+      expect(@klass.blah.yarr.y).to eql(6)
     end
 
     it "save should not save anything for it by default" do
@@ -821,17 +828,33 @@ describe Mixlib::Config do
     end
 
     it "save with include_defaults should save all defaults" do
-      expect(@klass.save(true)).to eql({ :blah => { :yarr => { :x => 5 } } })
+      expect(@klass.save(true)).to eql({ :blah => { :yarr => { :x => 5, :y => 6 } } })
     end
 
     it "saves any new values that are set in the context" do
       @klass.blah.yarr.x = 10
-      expect((saved = @klass.save)).to eql({ :blah => { :yarr => { :x => 10 } } })
+      @klass.blah.yarr.y = 11
+      expect((saved = @klass.save)).to eql({ :blah => { :yarr => { :x => 10, :y => 11 } } })
       @klass.reset
       expect(@klass.blah.yarr.x).to eql(5)
+      expect(@klass.blah.yarr.y).to eql(6)
       @klass.restore(saved)
       expect(@klass.blah.yarr.x).to eql(10)
-      expect(@klass.save).to eql({ :blah => { :yarr => { :x => 10 } } })
+      expect(@klass.blah.yarr.y).to eql(11)
+      expect(@klass.save).to eql({ :blah => { :yarr => { :x => 10, :y => 11 } } })
+    end
+
+    it "restores defaults not included in saved data" do
+      @klass.restore( :blah => { :yarr => { :x => 10 } } )
+      expect(@klass.blah.yarr.x).to eql(10)
+      expect(@klass.blah.yarr.y).to eql(6)
+    end
+
+    it "resmoves added properties not included in saved state" do
+      @klass.blah.yarr.z = 12
+      @klass.restore( :blah => { :yarr => { :x => 10 } } )
+      expect(@klass.blah.yarr.x).to eql(10)
+      expect(@klass.blah.yarr.z).to eql(nil)
     end
   end
 


### PR DESCRIPTION
This addresses an obscure but real edge case encountered by a user who was using chef provisioning to provision a couple hundred nodes in one `machine_batch`. In this scenario nodes are being provisioned in separate thread's. In each threads code path is this:
```
    def converge
      with_chef_config do
        Chef::Runner.new(run_context).converge
      end
    end
```

`with_chef_config` uses mixlib-config's `save` and `restore` to temporarily add state to `Chef::Config` and later restore it to its original. In the case of chef-provisioning it does not actually add any state while in the  `with_chef_config` block but `restore` is still called on `Chef::Config`. During the restore, all state is cleared and then its previous state is merged back in. So for a brief period of time `Chef::Config` is "naked" with only its god given defaults. In a high concurrency scenario, another thread may depend on the configured settings like a custom `trusted_certs_dir` for example. If it is pointed to the default directory, it may not find the certs it needs.

This PR, instead of clearing state, removes or resets state that does not match the saved state being restored.