### PR TITLE
Allow a config context to be set from another config context

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -174,6 +174,7 @@ module Mixlib
       end
       result
     end
+    alias :to_hash :save
 
     # Restore non-default values from the given hash.
     #
@@ -416,7 +417,7 @@ module Mixlib
       if configurables.has_key?(symbol)
         configurables[symbol].set(self.configuration, value)
       elsif config_contexts.has_key?(symbol)
-        config_contexts[symbol].restore(value)
+        config_contexts[symbol].restore(value.to_hash)
       else
         if config_strict_mode == :warn
           Chef::Log.warn("Setting unsupported config value #{symbol}.")

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -850,11 +850,19 @@ describe Mixlib::Config do
       expect(@klass.blah.yarr.y).to eql(6)
     end
 
-    it "resmoves added properties not included in saved state" do
+    it "removes added properties not included in saved state" do
       @klass.blah.yarr.z = 12
       @klass.restore( :blah => { :yarr => { :x => 10 } } )
       expect(@klass.blah.yarr.x).to eql(10)
       expect(@klass.blah.yarr.z).to eql(nil)
+    end
+
+    it "can set a config context from another context" do
+      @klass.blah.blyme = { :x => 7 }
+      blyme = @klass.blah.blyme
+      @klass.blah.yarr.x = 12
+      @klass.blah.yarr = blyme
+      expect(@klass.blah.yarr.x).to eql(7)
     end
   end
 


### PR DESCRIPTION
After 2.2.3 was released, chef travis began breaking on knife-windows external tests which copy a config context and add it back to the config later. While ultimately that is not that is not the best way to save and restore config values (one should use `save` and `restore` instead), it does introduce an element of negative surprise to set a config value with a config and get back a nil exception because the `restore`'s `hash.reject` returns nil when performed on a config instance.