### PR TITLE
Fix config_context_list/hash in strict mode

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -436,7 +436,7 @@ module Mixlib
     # block<Block>: a block that will be run in the context of this new config
     # class.
     def config_context_list(plural_symbol, singular_symbol, &block)
-      if configurables.has_key?(symbol)
+      if configurables.has_key?(plural_symbol)
         raise ReopenedConfigurableWithConfigContextError, "Cannot redefine config value #{plural_symbol} with a config context"
       end
 
@@ -468,7 +468,7 @@ module Mixlib
     # block<Block>: a block that will be run in the context of this new config
     # class.
     def config_context_hash(plural_symbol, singular_symbol, &block)
-      if configurables.has_key?(symbol)
+      if configurables.has_key?(plural_symbol)
         raise ReopenedConfigurableWithConfigContextError, "Cannot redefine config value #{plural_symbol} with a config context"
       end
 

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -115,6 +115,26 @@ describe Mixlib::Config do
     it "raises an error when you set an arbitrary config option with [:y] = 10" do
       expect(lambda { StrictClass[:y] = 10 }).to raise_error(Mixlib::Config::UnknownConfigOptionError, "Cannot set unsupported config value y.")
     end
+
+    it "does not break config_context_list" do
+      expect(lambda do
+        StrictClass.class_eval do
+          config_context_list(:lists, :list) do
+            default :y, 20
+          end
+        end
+      end).not_to raise_error
+    end
+
+    it "does not break config_context_hash" do
+      expect(lambda do
+        StrictClass.class_eval do
+          config_context_hash(:hashes, :hash) do
+            default :z, 20
+          end
+        end
+      end).not_to raise_error
+    end
   end
 
   describe "when a block has been used to set config values" do


### PR DESCRIPTION
Without this, `config_context_list` and `config_context_hash` are completely broken in strict mode:
```ruby
irb(main):001:0> require 'mixlib/config'
=> true
irb(main):002:0> class Config
irb(main):003:1>   extend Mixlib::Config
irb(main):004:1>   config_strict_mode true
irb(main):005:1>   config_context_list :tests, :test do
irb(main):006:2*     default :x, 5
irb(main):007:2>   end
irb(main):008:1> end
Mixlib::Config::UnknownConfigOptionError: Reading unsupported config value symbol.
```
This fixes that.