### PR TITLE
Fix variable name in config_context_{list, _hash}

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -436,7 +436,7 @@ module Mixlib
     # block<Block>: a block that will be run in the context of this new config
     # class.
     def config_context_list(plural_symbol, singular_symbol, &block)
-      if configurables.has_key?(symbol)
+      if configurables.has_key?(plural_symbol)
         raise ReopenedConfigurableWithConfigContextError, "Cannot redefine config value #{plural_symbol} with a config context"
       end
 
@@ -468,7 +468,7 @@ module Mixlib
     # block<Block>: a block that will be run in the context of this new config
     # class.
     def config_context_hash(plural_symbol, singular_symbol, &block)
-      if configurables.has_key?(symbol)
+      if configurables.has_key?(plural_symbol)
         raise ReopenedConfigurableWithConfigContextError, "Cannot redefine config value #{plural_symbol} with a config context"
       end
 

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1072,6 +1072,17 @@ describe Mixlib::Config do
       expect(klass.tests.first.y).to be 40
       expect(klass.tests.last.y).to be 50
     end
+
+    it "can use config_context_list in strict mode" do
+      klass = Class.new
+      klass.extend ::Mixlib::Config
+      klass.instance_eval do
+        config_strict_mode true
+        config_context_list(:tests, :test) do
+          default :y, 20
+        end
+      end
+    end
   end
 
   describe "config context hashes" do
@@ -1143,6 +1154,17 @@ describe Mixlib::Config do
       expect(klass.tests.length).to be 2
       expect(klass.tests[:one].y).to be 40
       expect(klass.tests[:two].y).to be 50
+    end
+
+    it "can use config_context_hash in strict mode" do
+      klass = Class.new
+      klass.extend ::Mixlib::Config
+      klass.instance_eval do
+        config_strict_mode true
+        config_context_hash(:tests, :test) do
+          default :y, 20
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fix a typo in the variable name used in the code for both `config_context_list` and `config_context_hash`.

Without the fix, when I try to use these methods in *strict mode*, I get the following error:

    Mixlib::Config::UnknownConfigOptionError:
     Reading unsupported config value symbol.

The included tests can reproduce the error if you revert the changes in `lib/mixlib/config.rb`