### PR TITLE
key? and has_key? should find subcontexts

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -153,7 +153,7 @@ module Mixlib
     # <True>:: If the config option exists
     # <False>:: If the config option does not exist
     def key?(key)
-      configuration.has_key?(key.to_sym)
+      configuration.has_key?(key.to_sym) || config_contexts.has_key?(key.to_sym)
     end
 
     alias_method :has_key?, :key?

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -935,6 +935,14 @@ describe Mixlib::Config do
       end
     end
 
+    it "has_key? finds the subcontext" do
+      expect(@klass.has_key?(:blah)).to be true
+    end
+
+    it "key? finds the subcontext" do
+      expect(@klass.key?(:blah)).to be true
+    end
+
     it "save does not save the hash for the config_context" do
       expect(@klass.save).to eql({})
     end


### PR DESCRIPTION
when we have:

`config[:knife][:whatever]`

then:

`config.key?(:knife)`

should be true, not false.

this actually fixes a regression in chef/chef cause by the prior PR interacting with some bizzare code in chef/chef
