### PR TITLE
Avoid converting to text representation when parsing JSON/TOML/etc

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -555,6 +555,25 @@ module Mixlib
       internal_get_or_set(method_symbol, *args)
     end
 
+    protected
+
+    # Given a (nested) Hash, apply it to the config object and any contexts.
+    #
+    # This is preferable to converting it to the string representation with
+    # the #to_dotted_hash method above.
+    #
+    # === Parameters
+    # hash<Hash>:: The hash to apply to the config oject
+    def apply_nested_hash(hash)
+      hash.each do |k, v|
+        if v.is_a? Hash
+          internal_get(k.to_sym).apply_nested_hash(v)
+        else
+          internal_set(k.to_sym, v)
+        end
+      end
+    end
+
     private
 
     # Given a (nested) Hash, turn it into a single top-level hash using dots as
@@ -574,23 +593,6 @@ module Mixlib
           ret.merge!(to_dotted_hash(v, key + "."))
         else
           ret[key] = v
-        end
-      end
-    end
-
-    # Given a (nested) Hash, apply it to the config object and any contexts.
-    #
-    # This is preferable to converting it to the string representation with
-    # the #to_dotted_hash method above.
-    #
-    # === Parameters
-    # hash<Hash>:: The hash to apply to the config oject
-    def apply_nested_hash(hash)
-      hash.each do |k, v|
-        if v.is_a? Hash
-          internal_get(k.to_sym).apply_nested_hash(v)
-        else
-          internal_set(k.to_sym, v)
         end
       end
     end

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1278,13 +1278,20 @@ alpha = "beta"
       {
         "alpha" => "beta",
         "foo" => %w{ bar baz matazz},
+        "bar" => { "baz" => { "fizz" => "buzz" } },
       }
     end
 
-    it "translates the Hash into method-style" do
+    it "configures the config object from a hash" do
+      ConfigIt.config_context :bar do
+        config_context :baz do
+          default :fizz, "quux"
+        end
+      end
       ConfigIt.from_hash(hash)
       expect(ConfigIt.foo).to eql(%w{ bar baz matazz })
       expect(ConfigIt.alpha).to eql("beta")
+      expect(ConfigIt[:bar][:baz][:fizz]).to eql("buzz")
     end
   end
 end

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1277,8 +1277,10 @@ alpha = "beta"
     let(:hash) do
       {
         "alpha" => "beta",
+        gamma: "delta",
         "foo" => %w{ bar baz matazz},
         "bar" => { "baz" => { "fizz" => "buzz" } },
+        "windows_path" => 'C:\Windows Has Awful\Paths',
       }
     end
 
@@ -1291,7 +1293,9 @@ alpha = "beta"
       ConfigIt.from_hash(hash)
       expect(ConfigIt.foo).to eql(%w{ bar baz matazz })
       expect(ConfigIt.alpha).to eql("beta")
+      expect(ConfigIt.gamma).to eql("delta")
       expect(ConfigIt[:bar][:baz][:fizz]).to eql("buzz")
+      expect(ConfigIt.windows_path).to eql('C:\Windows Has Awful\Paths')
     end
   end
 end


### PR DESCRIPTION
Directly apply the config as we descend recursively through the
Hash using internal_set/internal_get.
