### PR TITLE
Do not crash when loading undefined context from hash

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -569,7 +569,10 @@ module Mixlib
     def apply_nested_hash(hash)
       hash.each do |k, v|
         if v.is_a? Hash
-          internal_get(k.to_sym).apply_nested_hash(v)
+          # If loading from hash, and we reference a context that doesn't exist
+          # and warning/strict is off, we need to create the config context that we expected to be here.
+          context = internal_get(k.to_sym) || config_context(k.to_sym)
+          context.apply_nested_hash(v)
         else
           internal_set(k.to_sym, v)
         end

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1274,28 +1274,45 @@ describe Mixlib::Config do
   end
 
   describe ".from_hash" do
-    let(:hash) do
-      {
-        "alpha" => "beta",
-        gamma: "delta",
-        "foo" => %w{ bar baz matazz},
-        "bar" => { "baz" => { "fizz" => "buzz" } },
-        "windows_path" => 'C:\Windows Has Awful\Paths',
-      }
-    end
-
-    it "configures the config object from a hash" do
-      ConfigIt.config_context :bar do
-        config_context :baz do
-          default :fizz, "quux"
-        end
+    context "when contexts in the hash are defined" do
+      let(:hash) do
+        {
+          "alpha" => "beta",
+          gamma: "delta",
+          "foo" => %w{ bar baz matazz},
+          "bar" => { "baz" => { "fizz" => "buzz" } },
+          "windows_path" => 'C:\Windows Has Awful\Paths',
+        }
       end
-      ConfigIt.from_hash(hash)
-      expect(ConfigIt.foo).to eql(%w{ bar baz matazz })
-      expect(ConfigIt.alpha).to eql("beta")
-      expect(ConfigIt.gamma).to eql("delta")
-      expect(ConfigIt[:bar][:baz][:fizz]).to eql("buzz")
-      expect(ConfigIt.windows_path).to eql('C:\Windows Has Awful\Paths')
+      it "configures the config object from a hash" do
+        ConfigIt.config_context :bar do
+          config_context :baz do
+            default :fizz, "quux"
+          end
+        end
+        ConfigIt.from_hash(hash)
+        expect(ConfigIt.foo).to eql(%w{ bar baz matazz })
+        expect(ConfigIt.alpha).to eql("beta")
+        expect(ConfigIt.gamma).to eql("delta")
+        expect(ConfigIt[:bar][:baz][:fizz]).to eql("buzz")
+        expect(ConfigIt.windows_path).to eql('C:\Windows Has Awful\Paths')
+      end
+    end
+    context "when contexts in the hash are undefined and strict disabled" do
+      before do
+        ConfigIt.strict_mode = true
+      end
+      let(:hash) do
+        {
+          "brrr" => { "baz" => { "fizz" => "buzz" } },
+          "windows_path" => 'C:\Windows Has Awful\Paths',
+        }
+      end
+      it "configures the config object, creating contexts as needed" do
+        ConfigIt.from_hash(hash)
+        expect(ConfigIt[:brrr][:baz][:fizz]).to eql("buzz")
+        expect(ConfigIt.windows_path).to eql('C:\Windows Has Awful\Paths')
+      end
     end
   end
 end


### PR DESCRIPTION
When loading `from_hash` and with `strict_mode false`,
a config context that is not defined will cause
mixlib-config to crash.

This is because we used `internal_get` without checking
to see if the result was nil.  nil occurs when the
scenario above is met.  Now, we will define the context
when this happens, and continue to populate that context
from the hash.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~ I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
