### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -18,11 +18,11 @@
 # limitations under the License.
 #
 
-require "mixlib/config/version"
-require "mixlib/config/configurable"
-require "mixlib/config/unknown_config_option_error"
-require "mixlib/config/reopened_config_context_with_configurable_error"
-require "mixlib/config/reopened_configurable_with_config_context_error"
+require_relative "config/version"
+require_relative "config/configurable"
+require_relative "config/unknown_config_option_error"
+require_relative "config/reopened_config_context_with_configurable_error"
+require_relative "config/reopened_configurable_with_config_context_error"
 
 module Mixlib
   module Config


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>