### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -69,7 +69,7 @@ module Mixlib
     # === Parameters
     # filename<String>:: A filename to read from
     def from_yaml(filename)
-      require "yaml"
+      require "yaml" unless defined?(YAML)
       from_hash(YAML.load(IO.read(filename)))
     end
 
@@ -78,12 +78,12 @@ module Mixlib
     # === Parameters
     # filename<String>:: A filename to read from
     def from_json(filename)
-      require "json"
+      require "json" unless defined?(JSON)
       from_hash(JSON.parse(IO.read(filename)))
     end
 
     def from_toml(filename)
-      require "tomlrb"
+      require "tomlrb" unless defined?(Tomlrb)
       from_hash(Tomlrb.parse(IO.read(filename), symbolize_keys: true))
     end
 


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>