### PR TITLE
Remove parallel pin now that it supports Ruby 2.4 again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :docs do
 end
 
 group :test do
-  gem "parallel", "< 1.20" # remove this pin/dep when we drop ruby < 2.4
   gem "chefstyle", "1.5.9"
   gem "rake"
   gem "rspec", "~> 3.0"


### PR DESCRIPTION
We no longer need to pin this

Signed-off-by: Tim Smith <tsmith@chef.io>