### PR TITLE
Fix in nested_hash parsing in config

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -568,7 +568,10 @@ module Mixlib
     # hash<Hash>:: The hash to apply to the config object
     def apply_nested_hash(hash)
       hash.each do |k, v|
-        if v.is_a? Hash
+        if v.is_a?(Hash) && internal_get(k.to_sym).is_a?(Hash)
+          # If it is a plain config key (not a context) and the value is a Hash, plain merge the Hashes.
+          internal_set(k.to_sym, internal_get(k.to_sym).merge(v))
+        elsif v.is_a? Hash
           # If loading from hash, and we reference a context that doesn't exist
           # and warning/strict is off, we need to create the config context that we expected to be here.
           context = internal_get(k.to_sym) || config_context(k.to_sym)

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1298,6 +1298,27 @@ describe Mixlib::Config do
         expect(ConfigIt.windows_path).to eql('C:\Windows Has Awful\Paths')
       end
     end
+    context "when configurable and hash is defined" do
+      before :each do
+        @klass = Class.new
+        @klass.extend(::Mixlib::Config)
+        @klass.class_eval do
+          configurable(:environment) do |c|
+            c.defaults_to({})
+          end
+        end
+      end
+
+      let(:hash) do
+        {
+          environment: { "GEM_PATH" => "SOME_PATH" },
+        }
+      end
+      it "configures the config object from a hash" do
+        hash_config = @klass.from_hash(hash)
+        expect(hash_config[:environment]).to eql({ "GEM_PATH" => "SOME_PATH" })
+      end
+    end
     context "when contexts in the hash are undefined and strict disabled" do
       before do
         ConfigIt.strict_mode = true


### PR DESCRIPTION
Signed-off-by: Nikita Mathur <nikita.mathur@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added fix in nested_hash parsing in config, inside method `apply_nested_hash`. 
The error occurs in scenario when a `internal_get(k.to_sym)` returns an empty hash, it breaks and so this fix would just merge the hash values. 

This bug was reproduced while using license scout, and using configuration like this in license scout.yml file.
```
environment:
   SOME_KEY: SOME_VALUE
```
And since license_scout has a dependency on mixlib-config this needs to be fixed.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
