### PR TITLE
Use YAML.safe_load to prevent object deserialization from config files

### DIFF
--- a/lib/mixlib/config.rb
+++ b/lib/mixlib/config.rb
@@ -70,7 +70,11 @@ module Mixlib
     # filename<String>:: A filename to read from
     def from_yaml(filename)
       require "yaml" unless defined?(YAML)
-      from_hash(YAML.load(IO.read(filename)))
+      # Use safe_load so a config file can never instantiate arbitrary Ruby
+      # objects (a deserialization RCE vector). Symbols are permitted because
+      # they are commonly used in config files; this matches the default
+      # behavior of YAML.load on Psych 4 while remaining safe on older Psych.
+      from_hash(YAML.safe_load(IO.read(filename), permitted_classes: [Symbol], aliases: false))
     end
 
     # Parses valid JSON structure into Ruby

--- a/spec/mixlib/config_spec.rb
+++ b/spec/mixlib/config_spec.rb
@@ -1221,6 +1221,15 @@ describe Mixlib::Config do
       expect(ConfigIt.foo).to eql(%w{ bar baz matazz })
       expect(ConfigIt.alpha).to eql("beta")
     end
+
+    it "does not deserialize arbitrary Ruby objects from YAML" do
+      malicious_yaml = "--- !ruby/object:Gem::Requirement\nfoo: bar\n"
+      allow(IO).to receive(:read).with("config.yml").and_return(malicious_yaml)
+
+      expect do
+        ConfigIt.from_file("config.yml")
+      end.to raise_error(Psych::DisallowedClass)
+    end
   end
 
   describe ".from_json" do


### PR DESCRIPTION
## Problem

`from_yaml` calls `YAML.load` on the contents of a config file. On Psych versions prior to 4.0, `YAML.load` deserializes arbitrary Ruby objects from the document. Any application that loads a YAML config via `from_file`/`from_yaml` from a location an attacker can influence could therefore be made to instantiate attacker-controlled objects — a well-known remote code execution vector (the classic Psych gadget-chain attack).

While the gem requires Ruby >= 3.1 (which ships Psych 4, where `YAML.load` already behaves like `safe_load`), the safety currently depends on the ambient Psych version rather than on this code. Psych is a default gem and can be downgraded independently in a consumer's bundle, which would silently re-introduce the unsafe behavior.

## Fix

Switch `from_yaml` to `YAML.safe_load` with `permitted_classes: [Symbol], aliases: false`. This:

- Refuses arbitrary object deserialization regardless of the installed Psych version.
- Permits `Symbol`, which is commonly used in config files, matching the default behavior of `YAML.load` on Psych 4 — so there is no behavior change for valid configs on supported Ruby versions.

## Test

Adds a spec asserting that a malicious `!ruby/object:` document raises `Psych::DisallowedClass` instead of being deserialized. Full suite passes (156 examples, 0 failures).